### PR TITLE
Fixes for latest heroku python buildpack

### DIFF
--- a/bin/install_nodejs
+++ b/bin/install_nodejs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 NODE_VERSION=0.8.9
 NODE_BASENAME=node-v${NODE_VERSION}-linux-x64
@@ -15,11 +16,12 @@ tar -zxvf tmp-nodejs.tar.gz > /dev/null
 rm tmp-nodejs.tar.gz
 popd
 
-pushd $BUILD_DIR/.heroku/vendor
+mkdir -v -p $BUILD_DIR/.heroku
+pushd $BUILD_DIR/.heroku
 rm -rf node
 mv $tempdir/$NODE_BASENAME node
 popd
 
-ln -s ../../vendor/node/bin/node .heroku/venv/bin/node
-ln -s ../../vendor/node/bin/node-waf .heroku/venv/bin/node-waf
-ln -s ../../vendor/node/bin/npm .heroku/venv/bin/npm
+ln -s ../.heroku/node/bin/node bin/node
+ln -s ../.heroku/node/bin/node-waf bin/node-waf
+ln -s ../.heroku/node/bin/npm bin/npm

--- a/bin/run_compress
+++ b/bin/run_compress
@@ -5,7 +5,6 @@ indent() {
     [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
 }
 
-
 echo "Check if django-compressor is enabled."
 python $MANAGE_FILE help compress &> /dev/null && RUN_COMPRESS=true
 


### PR DESCRIPTION
The current scripts don't work very well with the latest buildpack from heroku (160497cb):
- `.heroku/vendor/` doesn't exist, I've changed it to use `.heroku/node/` (and create it if it doesn't exist), but I'm not sure if this is the 'correct' fix.
- errors in the script don't stop it from running

I've also noticed it's _really hard_ to get post_compile script updates to 'stick' - `bin/` gets cached by heroku so replacement files don't actually ever update. This is the workaround I've found:

```
heroku config:set CLEAN_VIRTUALENV=yes
git push heroku master  # this time will nuke old post_compile scripts, but then doesn't run them
heroku config:unset CLEAN_VIRTUALENV
git push heroku master  # this time post_compile scripts will run
```

Any insights?
